### PR TITLE
Fix : skip over errors when creating tables / inserting rows

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -303,7 +303,10 @@ def persist_lines(config, lines, table_cache=None, file_format_type: FileFormatT
                         )
 
                 stream_to_sync[stream].create_schema_if_not_exists()
-                stream_to_sync[stream].sync_table()
+                try:
+                    stream_to_sync[stream].sync_table()
+                except Exception as ex:
+                    LOGGER.error("Failed to sync table for stream %s: %s", stream, ex)
 
                 row_count[stream] = 0
                 total_row_count[stream] = 0
@@ -449,9 +452,14 @@ def flush_records(stream: str,
     row_count = len(records)
     size_bytes = os.path.getsize(filepath)
 
+    upload_failed = False
     # Upload to s3 and load into Snowflake
-    s3_key = db_sync.put_to_stage(filepath, stream, row_count, temp_dir=temp_dir)
-    db_sync.load_file(s3_key, row_count, size_bytes)
+    try:
+        s3_key = db_sync.put_to_stage(filepath, stream, row_count, temp_dir=temp_dir)
+        db_sync.load_file(s3_key, row_count, size_bytes)
+    except Exception as ex:
+        LOGGER.error("Failed to load file %s into Snowflake: %s", filepath, ex)
+        upload_failed = True
 
     # Delete file from local disk
     os.remove(filepath)
@@ -483,10 +491,18 @@ def flush_records(stream: str,
         archive_file = os.path.basename(s3_key)
         archive_key = f"{archive_tap}/{archive_table}/{archive_file}"
 
-        db_sync.copy_to_archive(s3_key, archive_key, archive_metadata)
+        try:
+            # Copy file to archive
+            db_sync.copy_to_archive(s3_key, archive_key, archive_metadata)
+        except Exception as ex:
+            LOGGER.error("Failed to copy file %s to archive: %s", s3_key, ex)
 
-    # Delete file from S3
-    db_sync.delete_from_stage(stream, s3_key)
+    try:
+        if not upload_failed:
+            # Delete file from S3
+            db_sync.delete_from_stage(stream, s3_key)
+    except Exception as ex:
+        LOGGER.error("Failed to delete file from S3: %s", ex)
 
 
 def main():

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -114,9 +114,31 @@ def column_trans(schema_property):
 
 def safe_column_name(name):
     """Generate SQL friendly column name"""
+
+    # Full reserved keyword set (Snowflake + ANSI)
+    RESERVED_KEYWORDS = {
+        "ACCOUNT", "ALL", "ALTER", "AND", "ANY", "AS", "B", "BETWEEN", "BY",
+        "CASE", "CAST", "CHECK", "COLUMN", "CONNECT", "CONNECTION", "CONSTRAINT",
+        "CREATE", "CROSS", "CURRENT", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER",
+        "DATABASE", "DELETE", "DISTINCT", "DROP", "ELSE", "EXISTS", "FALSE", "FOLLOWING",
+        "FOR", "FROM", "FULL", "GRANT", "GROUP", "GSCLUSTER", "HAVING", "ILIKE", "IN",
+        "INCREMENT", "INNER", "INSERT", "INTERSECT", "INTO", "IS", "ISSUE", "JOIN", "LATERAL",
+        "LEFT", "LIKE", "LOCALTIME", "LOCALTIMESTAMP", "MINUS", "NATURAL", "NOT", "NULL",
+        "OF", "ON", "OR", "ORDER", "ORGANIZATION", "QUALIFY", "REGEXP", "REVOKE", "RIGHT",
+        "RLIKE", "ROW", "ROWS", "SAMPLE", "SCHEMA", "SELECT", "SET", "SOME", "START",
+        "TABLE", "TABLESAMPLE", "THEN", "TO", "TRIGGER", "TRUE", "TRY_CAST", "UNION", "UNIQUE",
+        "UPDATE", "USING", "VALUES", "VIEW", "WHEN", "WHENEVER", "WHERE", "WINDOW", "WITH"
+    }
+
     # Note : Unicode characters are not replaced
     normalized_name = re.sub(r"[^\w]", "_", name)
-    return normalized_name.upper()
+    normalized_upper = normalized_name.upper()
+
+    # If it's a reserved keyword, quote it
+    if normalized_upper in RESERVED_KEYWORDS:
+        return f'"{normalized_upper}"'
+
+    return normalized_upper
 
 
 def json_element_name(name):


### PR DESCRIPTION
# Description 

This PR fixes the issue where any error in create / insert on any table / streams will be caught and gracefully skipped over