### PR TITLE
[Feat] [PQ-2952] Remove redundant get tables querying during pipeline run for every stream

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -709,6 +709,9 @@ class DbSync:
 
                 # Run everything in one transaction
                 try:
+                    # We run the table query only once, and since our
+                    # pipelines only write to one schema,
+                    # we dont need per schema cache
                     if len(_tables_cache) == 0:
                         _tables_cache = self.query(queries, max_records=99999)
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -17,6 +17,9 @@ from target_snowflake.upload_clients.snowflake_upload_client import SnowflakeUpl
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
+# Cache for get_tables() to avoid redundant SHOW TABLES queries per pipeline run
+_tables_cache = []
+
 
 def validate_config(config):
     """Validate configuration"""
@@ -688,7 +691,7 @@ class DbSync:
 
     def get_tables(self, table_schemas=None):
         """Get list of tables of certain schema(s) from snowflake metadata"""
-        tables = []
+        global _tables_cache
         if table_schemas:
             for schema in table_schemas:
                 queries = []
@@ -706,7 +709,8 @@ class DbSync:
 
                 # Run everything in one transaction
                 try:
-                    tables = self.query(queries, max_records=99999)
+                    if len(_tables_cache) == 0:
+                        _tables_cache = self.query(queries, max_records=99999)
 
                 # Catch exception when schema not exists and SHOW TABLES throws a ProgrammingError
                 # Regexp to extract snowflake error code and message from the exception message
@@ -717,7 +721,7 @@ class DbSync:
         else:
             raise Exception("Cannot get table columns. List of table schemas empty")
 
-        return tables
+        return _tables_cache
 
     def get_table_columns(self, table_schemas=None):
         """Get list of columns of a particular table from the particular schema"""


### PR DESCRIPTION
## Problem

Related ticket: [#PQ-2952](https://www.notion.so/peliqan/Snowflake-target-add-caching-on-get_tables-3041aa9b3879806989b7decea95d5e3c)

## Description

This PR adds module level cache on get_tables function so that expensive queries to find the list of tables is not called in every stream.

<img width="1030" height="171" alt="image" src="https://github.com/user-attachments/assets/98c3d426-c5fb-4afe-8c83-d9a129b3936f" />


## Tests:
- Ran with and without the change in this PR and observed reduction in queries executed. We only execute the get_tables once per pipeline run now.

