### PR TITLE
[PQ-3356] [fix] prefix temp/staging tables with pqtemp__ marker

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -20,6 +20,11 @@ from cryptography.hazmat.primitives import serialization
 # Cache for get_tables() to avoid redundant SHOW TABLES queries per pipeline run
 _tables_cache = []
 
+# Marker prefix for Peliqan temporary/staging tables. Any table whose name starts
+# with this (case-insensitive) is an intermediate table created during a load and
+# must be excluded from schema discovery and cleaned up by the Peliqan backend.
+TEMP_TABLE_MARKER = 'pqtemp__'
+
 
 def validate_config(config):
     """Validate configuration"""
@@ -436,7 +441,7 @@ class DbSync:
         sf_table_name = table_name.replace('.', '_').replace('-', '_').lower()
 
         if is_temporary:
-            sf_table_name = f'{sf_table_name}_temp'
+            sf_table_name = f'{TEMP_TABLE_MARKER}{sf_table_name}_temp'
 
         if without_schema:
             return f'"{sf_table_name.upper()}"'


### PR DESCRIPTION
## Reference Ticket

- PQ Ticket: PQ-3356

## Description

Note: after investigation, target-snowflake does **not** create any temp/staging/version tables. It stages data as files in the S3/internal stage and loads directly into the target table via `MERGE INTO <target> USING (... FROM @stage)` and `COPY INTO <target> FROM @stage` (`db_sync.py:580`, `db_sync.py:602`). FULL_TABLE replication is a no-op here — the `ACTIVATE_VERSION` handler only logs (`__init__.py:314`). The `is_temporary=True` branch that would build `pqtemp__<table>_temp` (`db_sync.py:443`, `create_table_query`) is never called; every caller passes `is_temporary=False`.

As a result, Snowflake could never produce the leftover `__<timestamp>` duplicate tables and was not a source of PQ-3356.

This change prefixes the (currently unused) `is_temporary` table name with the shared `pqtemp__` marker for consistency with the other Singer targets. It is **dormant/dead code today** and kept only as future-proofing in case a temp-table load path is introduced later.

## Tests

N/A - the current Snowflake load path creates no temp/staging table, so there is nothing to verify. Confirmed by code review of the load path (`MERGE`/`COPY ... FROM @stage`) and a full-repo search showing no temp-table creation.

---
Backend counterpart PR: https://github.com/Peliqan-io/baserow/pull/5534
